### PR TITLE
Updated Robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,15 @@
 User-agent: *
 Disallow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+# Yahoo!
+User-agent: Slurp
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /


### PR DESCRIPTION
Updated `robots.txt` file to allow Google to crawl the site. We do this because Google needs to see the `<meta name="robots" content="noindex,nofollow">` tag, so that it doesn't end up indexing it.